### PR TITLE
実行場所のフォルダを変換するフォルダにする機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/python_files/target/
-/python_files/README.md
+/python_files/
+/serif_tests
+/test_files
+/.vscode
 
 # Added by cargo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,241 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "get_input"
 version = "0.1.0"
 source = "git+https://github.com/ulibo-yuki/get_input#733a6ec6c47df0d730997841194c528c16be038b"
 
 [[package]]
-name = "voicefile_name_changer"
-version = "0.2.3"
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "voicefile_name_changer"
+version = "0.3.0"
+dependencies = [
+ "clap",
  "get_input",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "voicefile_name_changer"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
 get_input = { git = "https://github.com/ulibo-yuki/get_input"}
+clap = { version = "4.5.*", features = ["derive"] }
+# colored = "1.*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,21 @@
+use clap::Parser;
+// use colored::*;
 use get_input::get_input;
+use std::env;
 use std::fmt;
 use std::fs::{self, DirEntry, ReadDir};
+use std::io::stdout;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
+#[derive(Parser)]
+struct Args {
+    /// フォルダを指定
+    folder_path: Option<String>,
+}
+
 enum ErrorCodeList {
+    FailedGetPath,
     FailedGetTxtContent,
     FailedCreateFile,
     NoExtension,
@@ -11,11 +23,12 @@ enum ErrorCodeList {
     FailedRename,
     FailedConvert,
     FailedShowList,
+    ChangeCancel,
 }
-
 impl fmt::Display for ErrorCodeList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ErrorCodeList::FailedGetPath => write!(f, "Failed to get path"),
             ErrorCodeList::FailedGetTxtContent => write!(f, "Failed to get text content"),
             ErrorCodeList::FailedCreateFile => write!(f, "Failed to create file"),
             ErrorCodeList::NoExtension => write!(f, "File has no extension"),
@@ -23,26 +36,24 @@ impl fmt::Display for ErrorCodeList {
             ErrorCodeList::FailedRename => write!(f, "Failed to rename"),
             ErrorCodeList::FailedConvert => write!(f, "Failed to convert"),
             ErrorCodeList::FailedShowList => write!(f, "Failed to show list"),
+            ErrorCodeList::ChangeCancel => write!(f, "cancel"),
         }
     }
-}
-
-struct FilePathList {
-    old_path: PathBuf,
-    new_path: PathBuf,
-}
-
-fn get_files_list(path: &Path) -> Option<fs::ReadDir> {
-    fs::read_dir(path).ok()
 }
 
 fn get_txt_content(file_path: &Path) -> Result<String, ErrorCodeList> {
     match fs::read_to_string(file_path) {
         Ok(content) => Ok(content.chars().take(20).collect()),
-        Err(_) => Err(ErrorCodeList::FailedGetTxtContent),
+        Err(_) => {
+            if cfg!(debug_assertions) {
+                println!("{}", file_path.to_string_lossy());
+            }
+            Err(ErrorCodeList::FailedGetTxtContent)
+        }
     }
 }
 
+/// 受け取ったパスにフォルダを作成
 fn create_folder(input_path: &Path) -> Result<(), ErrorCodeList> {
     let path = input_path;
     match fs::create_dir_all(path) {
@@ -74,9 +85,16 @@ fn show_confirm_list(old_path: &Path, new_path: &Path) -> Result<(), ErrorCodeLi
     Ok(())
 }
 
+struct FilePathList {
+    old_path: PathBuf,
+    new_path: PathBuf,
+}
+
+/// パスのリスト(ReadDir)と親フォルダのパスを受け取り、全てをrename
 fn rename(file_path_list: ReadDir, parent_path: &Path) -> Result<i32, ErrorCodeList> {
     let mut count = 0;
     let mut list = Vec::<FilePathList>::new();
+
     for entry in file_path_list {
         let audio_path = match get_audio_path(entry) {
             //オーディオファイルのパスを取得
@@ -86,52 +104,111 @@ fn rename(file_path_list: ReadDir, parent_path: &Path) -> Result<i32, ErrorCodeL
                 _ => return Err(code),
             },
         };
+        // 新しいオーディオファイルの名前をテキストファイルから取得
         let new_audio_file_name = format!(
-            "{}.wav", //新しいオーディオファイルの名前をテキストファイルから取得
+            "{}.wav",
             get_txt_content(&audio_path.with_extension("txt"))
                 .map_err(|_| ErrorCodeList::FailedGetTxtContent)?
                 .trim()
         );
+        // ファイル名とフォルダパスを結合して新しいファイルパスを指定
         let new_audio_path = Path::new(parent_path)
             .join("renamed_files")
-            .join(new_audio_file_name); //新しいパスを生成
+            .join(new_audio_file_name);
+
         list.push(FilePathList {
             old_path: audio_path.clone(),
             new_path: new_audio_path.clone(),
         });
+        // 変換済みファイルを入れるフォルダを作成
         create_folder(&Path::new(parent_path).join("renamed_files"))?;
         show_confirm_list(&audio_path, &new_audio_path)?;
     }
-    println!("本当に変更しますか?(y/n)");
+
+    print!("本当に変更しますか?(y/n)>");
+    stdout().flush().unwrap();
     if get_input() == "y" {
         for path_vec in list {
             fs::rename(&path_vec.old_path, &path_vec.new_path)
                 .map_err(|_| ErrorCodeList::FailedRename)?;
             count += 1
         }
+        Ok(count)
+    } else {
+        Err(ErrorCodeList::ChangeCancel)
     }
-    Ok(count)
 }
 
+/// ## Examples
+/// 
+/// ### when place exefile in target directory.
+/// 
+/// ```
+/// //target file list
+/// user@pc target % ls
+/// 1.txt   1.wav   2.txt   2.wav   3.txt   3.wav   voicefile_name_changer
+/// user@pc target % cat 1.txt 2.txt 3.txt 
+/// first
+/// second
+/// three
+/// //rename with this tool
+/// //this tool run
+/// user@pc ~ % ~/voicefile_name_changer
+/// 1.wav                ---> first.wav
+/// 3.wav                ---> three.wav
+/// 2.wav                ---> second.wav
+/// 本当に変更しますか?(y/n)>y
+/// ```
+/// 
+/// ### when set the argument as a path
+/// 
+/// ```
+/// user@pc~ % ./voicefile_name_changer /target
+/// 1.wav                ---> first.wav
+/// 3.wav                ---> three.wav
+/// 2.wav                ---> second.wav
+/// 本当に変更しますか?(y/n)>y
+/// ```
 fn main() {
-    loop {
-        println!("パスを入力して下さい。");
-        let input_str = get_input();
-        let input_path = Path::new(&input_str);
-        let Some(files_list) = get_files_list(input_path) else {
-            eprintln!("ERROR: Failed to get files list");
-            continue;
-        };
-        match rename(files_list, input_path) {
-            Ok(count) => println!("{count}個のファイルを変換しました。"),
-            Err(code) => {
-                eprintln!("ERROR: {code}");
-                continue;
+    // loop {
+    let args = Args::parse();
+    // 引数にフォルダのパスがあった場合はそれを、ない場合はカレントディレクトリのパスを読む
+    let work_path = match match args.folder_path {
+        // 引数にパスがあった場合
+        Some(folder_path) => Ok(PathBuf::from(folder_path)),
+        // 引数にパスがない場合
+        None => {
+            // 実行ファイルのパスを返す
+            match (match env::current_exe() {
+                Ok(path) => path,
+                Err(_) => {
+                    eprintln!("{}", ErrorCodeList::FailedGetPath);
+                    return;
+                }
+            })
+            .parent()
+            {
+                Some(p) => Ok(p.to_path_buf()),
+                None => Err(ErrorCodeList::FailedGetPath),
             }
-        };
-        println!("もう一度使用しますか?(y/n)");
-        if get_input() == "n" {
-            break;
         }
-    }
+    } {
+        Ok(path) => path,
+        Err(code) => {
+            eprintln!("ERROR: {}", code);
+            return;
+        }
+    };
+
+    let Some(files_list) = fs::read_dir(&work_path).ok() else {
+        eprintln!("ERROR: Failed to get files list");
+        return;
+    };
+
+    match rename(files_list, &work_path) {
+        Ok(count) => println!("{count}個のファイルを変換しました。"),
+        Err(code) => {
+            eprintln!("ERROR: {}", code);
+        }
+    };
 }


### PR DESCRIPTION
- clapを利用して引数を取得
- 引数に指定されてない場合は実行ファイルの親フォルダ内のファイルをターゲットにする機能を追加